### PR TITLE
feat: 增加 follow_redirect 参数以支持 SSO 服务

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
-# 南京大学统一认证登陆
+# NJU Login
 
-从账号密码拿到 `CASTGC` cookie
+Login to authserver.nju.edu.cn and get `CASTGC` cookie.
 
 ```python3
 import nju_login
-response = nju_login.login('学号', '统一认证密码')
+response = nju_login.login('student_id', 'password')
 ```
 
-## 高级用法
+## Advanced Usage
 
-```
+### Custom CAPTCHA callback
+
+```python
 response = nju_login.login(
-  '学号',
-  '统一认证密码',
-  # 验证码识别回调，不传则使用ddddocr识别
+  'student_id',
+  'password',
+  # Custom CAPTCHA recognition callback, defaults to ddddocr
   lambda x: "45cx"
 )
 
-# Now the cookies in response represent your login state.
+# The cookies in response represent your login state.
 # Specifically the CASTGC cookie.
+```
+
+### Get full session (for SSO services like epay)
+
+```python
+session = nju_login.login(
+  'student_id',
+  'password',
+  follow_redirect=True,
+)
+
+# Session contains route, JSESSIONID, CASTGC, MOD_AUTH_CAS etc.
+# Ready to use with SSO services like epay.
+cookies = session.cookies.get_dict()
 ```

--- a/nju_login.py
+++ b/nju_login.py
@@ -41,7 +41,19 @@ def login(
     username: str,
     password: str,
     captcha_callback: Callable[[bytes], str] = do_captcha,
-) -> requests.Response:
+    follow_redirect: bool = False,
+) -> requests.Response | requests.Session:
+    """Login to authserver.nju.edu.cn and return auth cookies.
+
+    Args:
+        username: Student ID
+        password: Unified authentication password
+        captcha_callback: CAPTCHA recognition callback, defaults to ddddocr
+        follow_redirect: Whether to follow the 302 redirect after login.
+            False (default): Return Response, cookies only contain CASTGC etc.
+            True: Return requests.Session, cookies contain route, JSESSIONID,
+                  CASTGC, MOD_AUTH_CAS etc. Ready for SSO services like epay.
+    """
     session = requests.Session()
     session.headers.update(
         {
@@ -91,6 +103,13 @@ def login(
     login_response = session.post(
         "https://authserver.nju.edu.cn/authserver/login",
         data=data,
-        allow_redirects=False,
+        allow_redirects=follow_redirect,
     )
+
+    if follow_redirect:
+        # Follow redirect and verify login success
+        if "personalInfo" in login_response.url or "accountsecurity" in login_response.url:
+            return session
+        raise ValueError("Login failed, check your username and password")
+
     return login_response


### PR DESCRIPTION
## 问题

当前 `login()` 返回 `requests.Response` 对象，但 `response.cookies` 只包含 302 响应的 cookie（`CASTGC`、`happyVoyage`、`platformMultilingual`）。初始 GET 请求设置的 `JSESSIONID` 和 `route` 存放在内部的 `requests.Session` 中，**调用方无法获取**。

这导致依赖 SSO 的下游服务（如 epay.nju.edu.cn）无法正常认证，因为 authserver 需要通过 `JSESSIONID` 找到 `CASTGC` 对应的 session。

## 解决方案

给 `login()` 增加 `follow_redirect: bool = False` 参数：

- `follow_redirect=False`（默认）：当前行为，完全向后兼容
- `follow_redirect=True`：跟随 302 重定向，验证登录成功（检查最终 URL 是否包含 "personalInfo" 或 "accountsecurity"），返回 `requests.Session` 对象，包含**所有 cookies**（包括 `route`、`JSESSIONID`、`CASTGC`、`MOD_AUTH_CAS`、`WIS_PER_ENC`、`REFERERCE_TOKEN`）

### 用法

```python
# 原用法（不变）
resp = nju_login.login('学号', '密码')
castgc = resp.cookies.get('CASTGC')

# 新用法（SSO 服务）
session = nju_login.login('学号', '密码', follow_redirect=True)
cookies = session.cookies.get_dict()
# cookies 包含: route, JSESSIONID, CASTGC, MOD_AUTH_CAS, ...
```